### PR TITLE
Fixed bug with reverse order struct definition

### DIFF
--- a/lib/typed_struct.ex
+++ b/lib/typed_struct.ex
@@ -144,7 +144,7 @@ defmodule TypedStruct do
       unquote(block)
 
       @enforce_keys @ts_enforce_keys
-      defstruct @ts_fields
+      defstruct Enum.reverse(@ts_fields)
 
       TypedStruct.__struct_type__(@ts_types, unquote(opts))
     end


### PR DESCRIPTION
Currently, the attributes are pushed; this means that after the first element is added, when another element is added it becomes the first element and the original first element becomes element two. This can be fixed by reversing here where we call `defstruct`.

Fixes https://github.com/saleyn/typedstruct/issues/6

![Pre bugfix](https://github.com/user-attachments/assets/49a91d2e-fad4-43cf-b6f2-ec986e6510c9)
![Post bugfix](https://github.com/user-attachments/assets/f91ec60e-6932-467c-ab31-8bba8216cb52)
