### PR TITLE
Remove not-working with umbrella apps vsn fetcher

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,10 +5,9 @@ defmodule TypedStruct.MixProject do
   @repo_url "https://github.com/saleyn/typedstruct"
 
   def project do
-    version = vsn()
     [
       app: :typedstruct,
-      version: version,
+      version: @version,
       elixir: "~> 1.13",
       start_permanent: false,
       deps: deps(),
@@ -30,7 +29,7 @@ defmodule TypedStruct.MixProject do
         ],
         main: "readme",
         source_url: @repo_url,
-        source_ref: "v#{version}",
+        source_ref: "v#{@version}",
         formatters: ["html"]
       ],
 
@@ -105,44 +104,5 @@ defmodule TypedStruct.MixProject do
         "GitHub" => @repo_url
       }
     ]
-  end
-
-  # Obtain the version of this library
-  # If it's loaded as a dependency from Hex.pm, then the project contains
-  # ".hex" file, which contains the version.  If it's loaded from git, then
-  # we can use "git describe" command to format the version with a revision.
-  # Otherwise use a verbatim version from the attribute.
-  #
-  # NOTE: with this method of calculating the version number, you need to make
-  # sure that in the Github action the checkout includes:
-  # ```
-  #   - name: Checkout the repository
-  #     uses: actions/checkout@v4
-  #     with:
-  #       fetch-depth: 0
-  # ```
-  # This ensures that the git history is checked out with tags so that
-  # `git describe --tags` returns the proper version number.
-  defp vsn() do
-    hex_spec = Mix.Project.deps_path() |> Path.dirname() |> Path.join(".hex")
-    if File.exists?(hex_spec) do
-      hex_spec
-      |> File.read!()
-      |> :erlang.binary_to_term()
-      |> elem(1)
-      |> Map.get(:version)
-    else
-      with {ver, 0} <-
-            System.cmd("git", ~w(describe --always --tags),
-              stderr_to_stdout: true
-            ) do
-        ver
-        |> String.trim()
-        |> String.replace(~r/^v/, "")
-      else _ ->
-        #raise "Cannot determine application version!"
-        @version
-      end
-    end
   end
 end


### PR DESCRIPTION
Hello! We encountered a bit of a problem with the way the library's version is established in typedstruct. If you have an umbrella app and you decide to compile just one of the applications from within its folder - the versions of the dependency will mismatch as if the function `vsn/0` is run not from the root directory it will try to get the version with `git describe --always --tags` which if run from within the umbrella app (and not the dependency's dir, which I suppose was the intention) will give a tag that might not even be a tag of this repo. Not being entirely sure what the intention behind this dynamic version generation is - please consider either making the version static (as this PR suggests) or fixing the issue in a different way(?). The problem will appear anytime you try to compile (for instance to run tests) for just one umbrella app (from within its dir) not having previously compiled the project in its root or for instance elixir-ls might not work cause it tries to compile each app separately and bumps into dependency mismatch (and you have less control over what is compiled). At the very least the umbrella context of running `vsn/0` hasn't been accounted for.

I'd be grateful for more insight into why the version is established this way! Thanks!