### PR TITLE
Fix fields accumulating across multiple typedrecord declarations

### DIFF
--- a/lib/typed_struct.ex
+++ b/lib/typed_struct.ex
@@ -178,6 +178,11 @@ defmodule TypedStruct do
         unquote(name),
         unquote(tag)
       )
+
+      # Clean up accumulating attributes after each record definition
+      Enum.each(unquote(@record_accumulating_attrs), fn attr ->
+        Module.delete_attribute(__MODULE__, attr)
+      end)
     end
   end
 

--- a/test/typed_record_test.exs
+++ b/test/typed_record_test.exs
@@ -110,4 +110,23 @@ defmodule TypedRecordTest do
       end
     end
   end
+
+  defmodule MultipleRecords do
+    use TypedStruct
+
+    typedrecord :first do
+      field :a, integer(), default: 42
+    end
+
+    typedrecord :second do
+      field :b, String.t(), default: "hello"
+    end
+  end
+
+  test "multiple typedrecords in the same module" do
+    import MultipleRecords, only: [first: 0, second: 0]
+
+    assert first() == {:first, 42}
+    assert second() == {:second, "hello"}
+  end
 end


### PR DESCRIPTION
Fixed a bug where module attributes (@ts_fields, @ts_types, etc.) persisted across multiple typedrecord declarations in the same module, causing fields from earlier records to incorrectly appear in later ones.

The fix adds cleanup code to delete accumulating attributes after each typedrecord definition, ensuring each record starts with a clean slate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)