### PR TITLE
Find version via hex_metadata.config instead of .hex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -124,13 +124,13 @@ defmodule TypedStruct.MixProject do
   # This ensures that the git history is checked out with tags so that
   # `git describe --tags` returns the proper version number.
   defp vsn() do
-    hex_spec = Mix.Project.deps_path() |> Path.dirname() |> Path.join(".hex")
-    if File.exists?(hex_spec) do
-      hex_spec
-      |> File.read!()
-      |> :erlang.binary_to_term()
+    hex_metadata_config = Mix.Project.deps_path() |> Path.dirname() |> Path.join("hex_metadata.config")
+    if File.exists?(hex_metadata_config) do
+      hex_metadata_config
+      |> :file.consult()
       |> elem(1)
-      |> Map.get(:version)
+      |> List.keyfind("version", 0)
+      |> elem(1)
     else
       with {ver, 0} <-
             System.cmd("git", ~w(describe --always --tags),


### PR DESCRIPTION
The `.hex` file seem to be an outdated format, and it isn't present when building with Nix. You can easily get the same info using the `hex_metadata.config` file instead, which is described in the standard here: https://github.com/hexpm/specifications/blob/main/package_metadata.md.

I tested it locally by editing the `mix.exs` file in my deps folder and printing the version.

I'll just add that I think reading files and invoking git from a `mix.exs` as a library is bad practice, and I'd be happy to remove all of this logic as well if you want.